### PR TITLE
feat(event): adding support for event body as Object or String

### DIFF
--- a/example/daemon.ts
+++ b/example/daemon.ts
@@ -30,9 +30,9 @@ setEnvs();
 
 		privateChannel(event: Event) {
 			console.log(
-				`[consumer] Got a private message: ${
-					event.getBody()['message']
-				} ~> ${event.getName()}`,
+				`[consumer] Got a private message: ${JSON.stringify(
+					event.getBody(),
+				)} ~> ${event.getName()}`,
 			);
 		}
 	}

--- a/example/emitter.ts
+++ b/example/emitter.ts
@@ -28,9 +28,9 @@ setEnvs();
 	events.push(new Event(eventName, body));
 
 	eventName = 'resource.custom.private.service';
-	body = { message: 'Secret' };
+	const stringBody = `{ "message": "Secret"}`;
 
-	events.push(new Event(eventName, body));
+	events.push(new Event(eventName, stringBody));
 
 	eventName = 'resource.origin.action.all';
 	body = { bo: 'dy' };

--- a/example/listener.ts
+++ b/example/listener.ts
@@ -12,6 +12,7 @@ setEnvs();
 	console.log('Start receiving messages');
 
 	Listener.on(eventName, (event: Event, context: Context) => {
+		console.log('\n\n');
 		console.log(`-		Received a message from ${event.getName()}`);
 		console.log(`-  	Message headers ${JSON.stringify(event.getHeaders())}`);
 		console.log(`-		Message: ${JSON.stringify(event.getBody())}`);

--- a/lib/event.ts
+++ b/lib/event.ts
@@ -12,14 +12,14 @@ export type EventHeaders = {
 
 export type EventPayload = {
 	headers: EventHeaders;
-	body: Record<string, any>;
+	body: Record<string, any> | string;
 };
 
 export class Event {
 	private headers: EventHeaders;
 	constructor(
 		private name: string,
-		private readonly body: Record<string, any>,
+		private readonly body: Record<string, any> | string,
 		private readonly schemaVersion = 1.0,
 	) {}
 
@@ -35,10 +35,10 @@ export class Event {
 	}
 	/**
 	 * Returns the event body
-	 * @returns {Record<any, string>} - Record<any, string>
+	 * @returns {Record<any, string>} - Record<any, string> | string
 	 */
 	getBody(): Record<any, string> {
-		return this.body;
+		return typeof this.body === 'string' ? JSON.parse(this.body) : this.body;
 	}
 
 	/**

--- a/test/lib/event.spec.ts
+++ b/test/lib/event.spec.ts
@@ -51,6 +51,15 @@ describe('lib/event.ts', () => {
 		expect(eventBody).toStrictEqual(body);
 	});
 
+	it('getBody() - should return body string correctly', () => {
+		const stringBody = `{ "text": "a message body" }`;
+		const event = new Event('another.custom.action', stringBody);
+
+		const eventBody = event.getBody();
+
+		expect(eventBody).toStrictEqual(JSON.parse(stringBody));
+	});
+
 	it('getName() - should return name correctly', () => {
 		const body = { text: 'message body' };
 		const name = 'another.great.action';


### PR DESCRIPTION
## Problem
There was no support for writing event bodies as a String

## Solution
Adding extra type String for event body 

## Checklist before code review
- [x] Circle CI checks passed?
- [x] Your branch is updated(rebased) with master?
- [x] Did you write tests for your task, including regression tests?

## Reviewer Checklist
- [ ] I checked if the task has the tests
- [ ] I checked if the task has no security breach
- [ ] I checked if the task doesn't have unoptimized queries

## Checklist after merge
- [ ] If it's a _Sentry_ issue, mark it as resolved.
- [ ] Confirm deploy pass
- [ ] Notify product-team

## Deploy Notes
_Notes regarding deployment of the contained body of work. These should note any
new dependencies, new scripts, etc._

**New environment variables**:
- `env var` : env var details

**New scripts**:
- `script` : script details

**New dependencies**:
- `dependency` : dependency details

**New dev dependencies**:
- `dependency` : dependency details