### PR TITLE
fix(BUG-ND-001): normalize 3-part event names in Emitter before publishing

### DIFF
--- a/lib/emitter.ts
+++ b/lib/emitter.ts
@@ -15,6 +15,7 @@ export class Emitter {
 			if (!event.getName())
 				throw new MissingAttributeError(`Event name on position ${index}`);
 
+			event.setName(Event.fixedEventName(event.getName(), 'all'));
 			Config.broker.produce(event);
 		});
 	}

--- a/lib/event.ts
+++ b/lib/event.ts
@@ -50,6 +50,14 @@ export class Event {
 	}
 
 	/**
+	 * Sets the event name
+	 * @param {string} name - New event name
+	 */
+	setName(name: string): void {
+		this.name = name;
+	}
+
+	/**
 	 * Builds the headers based on the app_name and event name and schemaVersion
 	 * @returns {EventHeaders} - EventHeaders
 	 */


### PR DESCRIPTION
## Problem

`Emitter.trigger()` passed events to `broker.produce()` without normalizing 3-part event names. `Topic.produce()` then published using `event.getName()` as the AMQP routing key.

If a caller created an `Event` with a 3-part name (e.g. `resource.origin.action`), the routing key would be 3-part and would **not match any queue binding** (which uses 4-part names like `resource.origin.action.all`). Events were silently dropped with no error.

## Fix

Added `setName(name: string): void` to the `Event` class.

In `Emitter.trigger()`, before calling `Config.broker.produce(event)`:

```ts
event.setName(Event.fixedEventName(event.getName(), 'all'))
```

4-part event names pass through unchanged (`fixedEventName` returns them as-is). 3-part names get the `.all` destination appended, matching the queue binding.

## References
- Spec: `spec/contract.yml → routing_convention`
- Bug ID: `BUG-ND-001` in `.event_people.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)