### PR TITLE
chore: ignore Claude Code files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+# Claude Code
+.claude/
+CLAUDE.md


### PR DESCRIPTION
Adds `.claude/` and `CLAUDE.md` to `.gitignore` to prevent Claude Code internal files from appearing in `git status`.