### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "event_people",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Tool to simplify the communication of event based services.",
 	"main": "dist/lib/index.js",
 	"types": "dist/lib/index.d.ts",


### PR DESCRIPTION
Patch release with fix for nack(requeue=false) fallback on retry-publish failure (spec v1.1.1).